### PR TITLE
Enable Erlang Crash Dump files on Raspberry Pi3

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -37,7 +37,7 @@
 #--run-on-exit /bin/sh
 
 # Enable UTF-8 filename handling in Erlang and custom inet configuration
--e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump;PA_ALSA_PLUGHW=1;ERL_CRASH_DUMP_SECONDS=-1
+-e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump;ERL_CRASH_DUMP_SECONDS=-1;PA_ALSA_PLUGHW=1
 
 # Mount the application partition (run "man fstab" for field names)
 # NOTE: This must match the location in the fwup.conf. If it doesn't the system


### PR DESCRIPTION
The processing of **erlinit.config** during a build process apparently requires that all `ERL_CRASH_DUMP_*` names be adjacent on the "env" statement.

Thanks @RickCarlino :)
